### PR TITLE
Build binaries automatically using GitHub Actions

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,72 +1,70 @@
 name: Haskell CI
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    push:
+        branches: [master]
+    pull_request:
+        branches: [master]
 
 jobs:
-  build-ubuntu:
+    build-ubuntu:
+        runs-on: ubuntu-latest
 
-    runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 1
 
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1  
+            - name: Install dependencies
+              run: |
+                  cabal update
+                  cabal build --only-dependencies --enable-tests --enable-benchmarks
+            - name: Build
+              run: cabal build
+            - name: Install
+              run: cabal install --installdir=bin
+            - uses: actions/upload-artifact@v2
+              with:
+                  name: ${{ runner.os }}
+                  path: ./bin
 
-    - name: Install dependencies
-      run: |
-        cabal update
-        cabal build --only-dependencies --enable-tests --enable-benchmarks
-    - name: Build
-      run: cabal build
-    - name: Install
-      run: cabal install --installdir=bin
-    - uses: actions/upload-artifact@v2
-      with:
-        name: ${{ runner.os }}
-        path: ./bin
+    build-macos:
+        runs-on: macos-latest
 
-  build-macos:
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 1
+            - name: Install dependencies
+              run: |
+                  cabal update
+                  cabal build --only-dependencies --enable-tests --enable-benchmarks
+            - name: Build
+              run: cabal build
+            - name: Install
+              run: cabal install --installdir=bin
+            - uses: actions/upload-artifact@v2
+              with:
+                  name: ${{ runner.os }}
+                  path: ./bin
 
-    runs-on: macos-latest
+    # build-windows:
 
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1  
-    - name: Install dependencies
-      run: |
-        cabal update
-        cabal build --only-dependencies --enable-tests --enable-benchmarks
-    - name: Build
-      run: cabal build
-    - name: Install
-      run: cabal install --installdir=bin
-    - uses: actions/upload-artifact@v2
-      with:
-        name: ${{ runner.os }}
-        path: ./bin
+    #   runs-on: windows-latest
 
-  build-windows:
-
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1  
-    - name: Install dependencies
-      run: |
-        cabal update
-        cabal build --only-dependencies --enable-tests --enable-benchmarks
-    - name: Build
-      run: cabal build
-    - name: Install
-      run: cabal install --installdir=bin
-    - uses: actions/upload-artifact@v2
-      with:
-        name: ${{ runner.os }}
-        path: ./bin
+    #   steps:
+    #   - uses: actions/checkout@v2
+    #     with:
+    #       fetch-depth: 1
+    #   - name: Install dependencies
+    #     run: |
+    #       cabal update
+    #       cabal build --only-dependencies --enable-tests --enable-benchmarks
+    #   - name: Build
+    #     run: cabal build
+    #   - name: Install
+    #     run: cabal install --installdir=bin
+    #   - uses: actions/upload-artifact@v2
+    #     with:
+    #       name: ${{ runner.os }}
+    #       path: ./bin

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,45 @@
+name: Haskell CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1  
+    - uses: actions/setup-haskell@v1
+      with:
+        ghc-version: '8.10.3'
+        cabal-version: '3.2'
+
+    - name: Cache
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-cabal
+      with:
+        path: ~/.cabal
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Install dependencies
+      run: |
+        cabal update
+        cabal build --only-dependencies --enable-tests --enable-benchmarks
+    - name: Build
+      run: cabal build
+    - uses: actions/upload-artifact@v2
+      with:
+        name: pandoc-unicode-math-${{ runner.os }}
+        path: pandoc-unicode-math
+    

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -38,8 +38,10 @@ jobs:
         cabal build --only-dependencies --enable-tests --enable-benchmarks
     - name: Build
       run: cabal build
+    - name: Install
+      run: cabal install --installdir=bin
     - uses: actions/upload-artifact@v2
       with:
-        name: pandoc-unicode-math-${{ runner.os }}
-        path: pandoc-unicode-math
+        name: ${{ runner.os }}
+        path: ./bin
     

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  build-ubuntu:
 
     runs-on: ubuntu-latest
 
@@ -44,4 +44,77 @@ jobs:
       with:
         name: ${{ runner.os }}
         path: ./bin
-    
+
+  build-macos:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1  
+    - uses: actions/setup-haskell@v1
+      with:
+        ghc-version: '8.10.3'
+        cabal-version: '3.2'
+
+    - name: Cache
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-cabal
+      with:
+        path: ~/.cabal
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+    - name: Install dependencies
+      run: |
+        cabal update
+        cabal build --only-dependencies --enable-tests --enable-benchmarks
+    - name: Build
+      run: cabal build
+    - name: Install
+      run: cabal install --installdir=bin
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ runner.os }}
+        path: ./bin
+
+  build-windows:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1  
+    - uses: actions/setup-haskell@v1
+      with:
+        ghc-version: '8.10.3'
+        cabal-version: '3.2'
+
+    - name: Cache
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-cabal
+      with:
+        path: ~/.cabal
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+    - name: Install dependencies
+      run: |
+        cabal update
+        cabal build --only-dependencies --enable-tests --enable-benchmarks
+    - name: Build
+      run: cabal build
+    - name: Install
+      run: cabal install --installdir=bin
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ runner.os }}
+        path: ./bin

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,22 +15,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 1  
-    - uses: actions/setup-haskell@v1
-      with:
-        ghc-version: '8.10.3'
-        cabal-version: '3.2'
-
-    - name: Cache
-      uses: actions/cache@v1
-      env:
-        cache-name: cache-cabal
-      with:
-        path: ~/.cabal
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
 
     - name: Install dependencies
       run: |
@@ -53,22 +37,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 1  
-    - uses: actions/setup-haskell@v1
-      with:
-        ghc-version: '8.10.3'
-        cabal-version: '3.2'
-
-    - name: Cache
-      uses: actions/cache@v1
-      env:
-        cache-name: cache-cabal
-      with:
-        path: ~/.cabal
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
     - name: Install dependencies
       run: |
         cabal update
@@ -90,22 +58,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 1  
-    - uses: actions/setup-haskell@v1
-      with:
-        ghc-version: '8.10.3'
-        cabal-version: '3.2'
-
-    - name: Cache
-      uses: actions/cache@v1
-      env:
-        cache-name: cache-cabal
-      with:
-        path: ~/.cabal
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
     - name: Install dependencies
       run: |
         cabal update


### PR DESCRIPTION
Currently macOS and Windows are running. To access the binaries of a commit:
1. Go to the Actions tab and Click on a commit
<img width="994" alt="Screen Shot 2021-01-17 at 01 13 48" src="https://user-images.githubusercontent.com/34147102/104827790-017de800-5862-11eb-8bac-d3914050342d.png">
2. Go to the bottom of the page and download the artifact for your platform
<img width="1088" alt="Screen Shot 2021-01-17 at 01 14 24" src="https://user-images.githubusercontent.com/34147102/104827825-5c174400-5862-11eb-8c53-141a2c2db157.png">

windows is not supported because I wasn't able to install libpcre
